### PR TITLE
fix(docker): tell Git that the workdir is safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ ENV _GIT_SINCE= \
     TERM=xterm-256color
 
 WORKDIR /git
+RUN git config --global --add safe.directory /git
 ENTRYPOINT [ "/usr/local/bin/docker-entrypoint" ]
 CMD [ "/usr/bin/git", "quick-stats" ]


### PR DESCRIPTION
When bind-mounting a Git repository to the workdir, Git would complain about 'dubious ownership'.

We add an exception to the global Git config, in the way Git tells us to. This should be safe since
- we run in a container, and
- the user can set the mount to read-only.

fixes issue #179