### PR TITLE
Anchor regexps in commitsPerAuthor()

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -715,10 +715,10 @@ function commitsPerAuthor()  {
     optionPicked "Git commits per author:"
     local authorCommits=$(git -c log.showSignature=false log --use-mailmap \
                           $_merges "$_since" "$_until" $_log_options \
-                          | grep -i Author: | cut -c9-)
+                          | grep -i '^Author:' | cut -c9-)
     local coAuthorCommits=$(git -c log.showSignature=false log --use-mailmap \
                             $_merges "$_since" "$_until" $_log_options \
-                            | grep -i Co-Authored-by: | cut -c21-)
+                            | grep -i '^    Co-Authored-by:' | cut -c21-)
 
     if [[ -z "${coAuthorCommits}" ]]; then
         allCommits="${authorCommits}"


### PR DESCRIPTION
Fixes:

```console
$ git clone -q https://github.com/util-linux/util-linux.git
$ git -C util-linux quick-stats -a | grep -w uthor
        23    uthor                                    Karel Zak              0.1%
        3     uthor                                    Ondrej Oprala          0.0%
        2     uthor                                    Samuel Thibault        0.0%
        ...
```