### PR TITLE
Fix default until-date in other locales

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -27,7 +27,7 @@ _until=${_GIT_UNTIL:-}
 if [[ -n "${_until}" ]]; then
     _until="--until=$_until"
 else
-    _until="--until=$(date '+%a, %d %b %Y %H:%M:%S %Z')"
+    _until="--until=$(LC_TIME=C date '+%a, %d %b %Y %H:%M:%S %Z')"
 fi
 
 # Set files or directories to be excluded in stats


### PR DESCRIPTION
While checking the tests for #186, I got an error-message from `seq` about an invalid argument.
I have traced it back to the default `until`-date not being properly parsed when the system-locale is not English (German in my case).
This is a problem in normal operation as well:
```console
$ ./git-quick-stats -Y
Git commits by year:

	year	sum
seq: ungültiges Gleitkommaargument: »«
„seq --help“ liefert weitere Informationen.
```
(Error-message translates to `invalid floating-point argument ""`)

This is because `date` (used for setting the default `until`-date) produces localized output by default.
However, `date -d` cannot parse this localized output but requires a [locale independent format](https://www.gnu.org/software/coreutils/manual/html_node/Options-for-date.html#index-_002dd-19).
This commit sets the locale in the default `until`-date to a format parsable by `date` as described in the linked article.