### PR TITLE
Flatten arrays for wider awk compatibility

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -138,7 +138,7 @@ function commitsCalendarByAuthor() {
             cmd | getline weekday;
             close(cmd); 
             # weekday: 1=Mon, ..., 7=Sun
-            count[weekday][mon]++; 
+            count[weekday * 12 + mon]++;
         }
         END {
             # Output matrix
@@ -151,7 +151,7 @@ function commitsCalendarByAuthor() {
                 else if (d==6) printf "Sat   ";
                 else if (d==7) printf "Sun   "; 
                 for (m=1; m<=12; m++) {
-                    c = count[d][m]+0; 
+                    c = count[d * 12 + m]+0;
                     if (c==0) 
                         out="...";
                     else if (c<=9)  


### PR DESCRIPTION
* The current implementation of the calendar heatmap by author contains multidimensional arrays. This works with newer versions of awk, but can cause issues with systems that use an older variant which cannot easily handle these calculations. macOS is especially impacted by this.

  By flattening the arrays from a multidimensional array to a single dimensional array, we can maintain greater compatibility across awk variants without requiring the user to install additional versions of awk.

Addresses issue #194